### PR TITLE
fix future filter when "both" choice is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixes `future` filter when "any" choice is selected.
+- Fixes `future` filter when "both" choice is selected.
 
 ## 1.0.2 - 2023-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixes `future` filter using choices as strings instead of booleans.
+- Fixes `future` filter when "any" choice is selected.
 
 ## 1.0.2 - 2023-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixed
+
+- Fixes `future` filter using choices as strings instead of booleans.
+
 ## 1.0.2 - 2023-03-01
 
 ### Fixed

--- a/modules/@apostrophecms/blog-page/index.js
+++ b/modules/@apostrophecms/blog-page/index.js
@@ -9,10 +9,10 @@ module.exports = {
   extendMethods(self) {
     return {
       indexQuery(_super, req) {
-        return _super(req).future('past');
+        return _super(req).future(false);
       },
       showQuery(_super, req) {
-        return _super(req).future('past');
+        return _super(req).future(false);
       }
     };
   }

--- a/modules/@apostrophecms/blog-page/index.js
+++ b/modules/@apostrophecms/blog-page/index.js
@@ -9,10 +9,10 @@ module.exports = {
   extendMethods(self) {
     return {
       indexQuery(_super, req) {
-        return _super(req).future(false);
+        return _super(req).future('past');
       },
       showQuery(_super, req) {
-        return _super(req).future(false);
+        return _super(req).future('past');
       }
     };
   }

--- a/queries.js
+++ b/queries.js
@@ -24,7 +24,7 @@ module.exports = (self, query) => {
           }
         },
         launder(value) {
-          return self.apos.launder.booleanOrNull(value);
+          return self.apos.launder.booleanOrNull(value || null);
         },
         choices() {
           return [

--- a/queries.js
+++ b/queries.js
@@ -24,7 +24,9 @@ module.exports = (self, query) => {
           }
         },
         launder(value) {
-          return self.apos.launder.booleanOrNull(value || null);
+          return self.apos.launder.booleanOrNull(
+            value === '' ? null : value
+          );
         },
         choices() {
           return [


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes `future` filter when "Both" choice is selected.

## What are the specific steps to test this change?

Check that blog with a future publication date are displayed when "Both" is selected:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/8301962/218795774-81af92cb-ec00-4594-821e-f30e7ac913b0.png">

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
