### PR TITLE
Remove `safeFor` properties from queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Changes
+
+- Removes the outdated `safeFor` property from the custom queries.
+
 ## 1.0.3 - 2023-02-17
 
 ### Fixed

--- a/queries.js
+++ b/queries.js
@@ -49,7 +49,6 @@ module.exports = (self, query) => {
       // Filter by year, in YYYY format.
       year: {
         def: null,
-        safeFor: 'public',
         finalize() {
           const year = query.get('year');
           if (!year) {
@@ -94,7 +93,6 @@ module.exports = (self, query) => {
       // Filter by month, in YYYY-MM format.
       month: {
         def: null,
-        safeFor: 'public',
         finalize() {
           const month = query.get('month');
 
@@ -140,7 +138,6 @@ module.exports = (self, query) => {
       // Filter by day, in YYYY-MM-DD format.
       day: {
         def: null,
-        safeFor: 'public',
         finalize() {
           const day = query.get('day');
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

This PR removes the `safeFor` properties from the custom query builders. This property was present in Apostrophe v2.x, but is no longer present in v3.x. This is being done primarily because the extension will be used in the Onboarding tutorials and this extra property would have to be explained.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [X] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- X ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
